### PR TITLE
fix: Exclude .github repo from matrixed repo governance

### DIFF
--- a/.github/workflows/list-repos.yml
+++ b/.github/workflows/list-repos.yml
@@ -116,9 +116,9 @@ jobs:
             }
             
             // construct search query
-            let query = `user:${inputOwner}`
+            let query = `user:${inputOwner}+NOT .github in:name`
             if (inputRepoFilter) {
-              query += `+${inputRepoFilter} in:name`
+              query += `AND ${inputRepoFilter} in:name`
             }
             // https://docs.github.com/en/search-github/searching-on-github/searching-for-repositories
             query += `+is:public+is:internal+is:private+archived:false+fork:true`

--- a/.github/workflows/repo-gov-all.yml
+++ b/.github/workflows/repo-gov-all.yml
@@ -29,9 +29,10 @@ on:
 
   push:
     paths:
-      - '.github/workflows/repo-gov.yml'
       - '.github/workflows/repo-gov-all.yml'
       - '.github/workflows/repo-gov-matrixed.yml'
+      - '.github/workflows/list-repos.yml'
+      - '.github/workflows/repo-gov.yml'
       - 'standardized-workflows/**'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel

--- a/.github/workflows/repo-gov-matrixed.yml
+++ b/.github/workflows/repo-gov-matrixed.yml
@@ -34,6 +34,7 @@ on:
     paths:
       - '.github/workflows/repo-gov.yml'
       - '.github/workflows/repo-gov-matrixed.yml'
+      - '.github/workflows/list-repos.yml'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
## Description
Modify the list repo code to exclude this repo (.github) from updates for the matrixed governance application.

## Motivation and Context
Repo seems to fail when it attempts to update itself indirectly.  The repo-gov workflow maintains this repo itself, so we should exclude it from being in the decentralized repo list that we maintain automatically.