### PR TITLE
fix(copilot-security-recommendations): Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-dacpac.yml
+++ b/.github/workflows/build-dacpac.yml
@@ -1,5 +1,8 @@
 name: Build DACPACs
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -1,5 +1,8 @@
 name: 'Build dotnet'
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/build-ispac.yml
+++ b/.github/workflows/build-ispac.yml
@@ -1,5 +1,8 @@
 name: Build ISPACs
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -1,5 +1,8 @@
 name: 'Code-Owners are Team(s)'
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/create-bug.yml
+++ b/.github/workflows/create-bug.yml
@@ -1,5 +1,8 @@
 name: Create an Issue documenting the bug
 
+permissions:
+  contents: read
+
 # Controls when the workflow will run
 on:
   workflow_call:

--- a/.github/workflows/deploy-dacpac.yml
+++ b/.github/workflows/deploy-dacpac.yml
@@ -1,5 +1,8 @@
 name: Deploy DACPACs
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/deploy-ispac.yml
+++ b/.github/workflows/deploy-ispac.yml
@@ -1,5 +1,8 @@
 name: Deploy ISPACs
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/get-app-token.yml
+++ b/.github/workflows/get-app-token.yml
@@ -1,5 +1,8 @@
 name: Get GitHub App Token
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/lint-terraform.yml
+++ b/.github/workflows/lint-terraform.yml
@@ -1,5 +1,9 @@
 # TODO: Make this a pre-commit action
 name: 'Lint: Terraform'
+
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/list-env-variables.yml
+++ b/.github/workflows/list-env-variables.yml
@@ -1,6 +1,9 @@
 # TODO: Need to make sure secrets are secure
 name: 'List Environment Variables'
 
+permissions:
+  contents: read
+
 on:
   workflow_run:
     workflows: [ 'Mock Test Workflow for Other Branches' ]

--- a/.github/workflows/list-env-variables.yml
+++ b/.github/workflows/list-env-variables.yml
@@ -41,7 +41,6 @@ jobs:
           # GITHUB_JOBS: ${{ toJson(jobs) }}
           GITHUB_STEPS: ${{ toJson(steps) }}
           GITHUB_RUNNER: ${{ toJson(runner) }}
-          GITHUB_SECRETS: ${{ toJson(secrets) }}
           # GITHUB_STRATEGY: ${{ toJson(strategy) }}
           # GITHUB_MATRIX: ${{ toJson(matrix) }}
           GITHUB_NEEDS: ${{ toJson(needs) }}

--- a/.github/workflows/list-env-variables.yml
+++ b/.github/workflows/list-env-variables.yml
@@ -41,6 +41,7 @@ jobs:
           # GITHUB_JOBS: ${{ toJson(jobs) }}
           GITHUB_STEPS: ${{ toJson(steps) }}
           GITHUB_RUNNER: ${{ toJson(runner) }}
+          # GITHUB_SECRETS: ${{ toJson(secrets) }}
           # GITHUB_STRATEGY: ${{ toJson(strategy) }}
           # GITHUB_MATRIX: ${{ toJson(matrix) }}
           GITHUB_NEEDS: ${{ toJson(needs) }}

--- a/.github/workflows/list-repos.yml
+++ b/.github/workflows/list-repos.yml
@@ -1,5 +1,8 @@
 name: List Repos Matching a Name Pattern
 
+permissions:
+  contents: read
+
 # Controls when the workflow will run
 on:
   workflow_call:

--- a/.github/workflows/matrix-environments.yml
+++ b/.github/workflows/matrix-environments.yml
@@ -1,5 +1,8 @@
 name: Get Matrix of Environments by Branch
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/plan-dacpac.yml
+++ b/.github/workflows/plan-dacpac.yml
@@ -1,5 +1,8 @@
 name: Plan DACPACs
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/pr-controls.yml
+++ b/.github/workflows/pr-controls.yml
@@ -19,6 +19,9 @@ on:
 jobs:
   pr_title:
     name: Check PR Title 📝
+    permissions:
+      contents: read
+      pull-requests: read
     runs-on: ${{ fromJSON(inputs.runs-on || '[ "ubuntu-latest" ]' ) }}
     steps:
       #TODO: Deprecated NodeJS Version

--- a/.github/workflows/pr-controls.yml
+++ b/.github/workflows/pr-controls.yml
@@ -1,5 +1,8 @@
 name: 'Controls to Standardize Pull Requests'
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release
 
+permissions:
+  contents: read
+
 on:
   push:
     # Sequence of patterns matched against refs/heads

--- a/.github/workflows/repo-gov-all.yml
+++ b/.github/workflows/repo-gov-all.yml
@@ -1,5 +1,8 @@
 name: Organization Repository Governance
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.repository_owner }}-repo-gov
   cancel-in-progress: true

--- a/.github/workflows/repo-gov-matrixed.yml
+++ b/.github/workflows/repo-gov-matrixed.yml
@@ -1,5 +1,8 @@
 name: Matrixed Repository Governance
 
+permissions:
+  contents: read
+
 # Controls when the workflow will run
 on:
   workflow_call:

--- a/.github/workflows/repo-gov.yml
+++ b/.github/workflows/repo-gov.yml
@@ -1,5 +1,8 @@
 name: Repository Governance
 
+permissions:
+  contents: read
+
 # Controls when the workflow will run
 on:
   workflow_dispatch:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,6 +15,9 @@ on:
     paths:
       - '.github/workflows/stale.yml'
 
+permissions:
+  contents: read
+
 jobs:
   get-app-token:
     name: Get GitHub App Token
@@ -29,6 +32,9 @@ jobs:
     name: Close Issues w/o Update for 10-days, Mark Issues and PRs Older than 90-days as Stale
     needs: get-app-token
     runs-on: ${{ fromJSON(inputs.runs-on || '[ "ubuntu-latest" ]') }}
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - name: Clean Agent Workspace
         uses: tiacsys/clean-after-action@v3.0.0
@@ -72,7 +78,6 @@ jobs:
     needs: get-app-token
     runs-on: ${{ fromJSON(inputs.runs-on || '[ "ubuntu-latest" ]') }}
     permissions:
-      contents: read
       issues: write
     steps:
       #TODO: Deprecated NodeJS Version

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,8 @@
 name: 'Issue & PR Maintenance'
+
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:
@@ -14,9 +18,6 @@ on:
   push:
     paths:
       - '.github/workflows/stale.yml'
-
-permissions:
-  contents: read
 
 jobs:
   get-app-token:
@@ -79,6 +80,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs-on || '[ "ubuntu-latest" ]') }}
     permissions:
       issues: write
+      pull-requests: write
     steps:
       #TODO: Deprecated NodeJS Version
       - name: Clean Agent Workspace

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -71,6 +71,9 @@ jobs:
     name: Lock issues and PRs that have been closed for 60-days
     needs: get-app-token
     runs-on: ${{ fromJSON(inputs.runs-on || '[ "ubuntu-latest" ]') }}
+    permissions:
+      contents: read
+      issues: write
     steps:
       #TODO: Deprecated NodeJS Version
       - name: Clean Agent Workspace

--- a/.github/workflows/units-dotnet.yml
+++ b/.github/workflows/units-dotnet.yml
@@ -1,5 +1,8 @@
 name: 'Unit Tests: dotnet'
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/units-ispac.yml
+++ b/.github/workflows/units-ispac.yml
@@ -1,5 +1,8 @@
 name: 'Unit Tests: SSIS'
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/units-powershell.yml
+++ b/.github/workflows/units-powershell.yml
@@ -1,5 +1,8 @@
 name: 'Unit Tests: PowerShell'
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/units-python.yml
+++ b/.github/workflows/units-python.yml
@@ -1,5 +1,8 @@
 name: 'Unit Tests: Python'
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/units-terraform.yml
+++ b/.github/workflows/units-terraform.yml
@@ -1,4 +1,8 @@
 name: 'Unit Tests: Terraform'
+
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/sassy-bulldog/.github/security/code-scanning/18](https://github.com/sassy-bulldog/.github/security/code-scanning/18)

To fix the issue, we need to add a `permissions` block to the `lock` job to explicitly limit the permissions of the `GITHUB_TOKEN`. Since the job only needs to lock issues and pull requests, the minimal permissions required are `contents: read` and `issues: write`. This ensures that the token has only the necessary access to perform its tasks.

The changes should be made in the `.github/workflows/stale.yml` file, specifically within the `lock` job definition. No additional dependencies or imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
